### PR TITLE
Adding documentation on how to compile the package from source

### DIFF
--- a/docs/openwrt_compile_source/Makefile
+++ b/docs/openwrt_compile_source/Makefile
@@ -1,0 +1,59 @@
+include $(TOPDIR)/rules.mk
+
+# Name, version and release number
+# The name and version of your package are used to define the variable to point to the build directory of your package: $(PKG_BUILD_DIR)
+PKG_NAME:=tinyHIPPO
+PKG_VERSION:=0.1
+PKG_RELEASE:=1
+
+# Source settings (i.e. where to find the source codes)
+# This is a custom variable, used below
+SOURCE_DIR:=src/
+
+include $(INCLUDE_DIR)/package.mk
+
+# Package definition; instructs on how and where our package will appear in the overall configuration menu ('make menuconfig')
+define Package/tinyHIPPO
+	SECTION:=examples
+	CATEGORY:=Examples
+	DEPENDS:=+python3 +scapy +python3-pip +sqlite3-cli +nmap +python3-sqlalchemy
+	TITLE:=Capstone IDS Project for CY4930, Northeastern University
+endef
+
+# Package description; a more verbose description on what our package does
+define Package/tinyHIPPO/description
+	A simple intrusion detection and privacy protection system for IoT devices
+endef
+
+# Package preparation instructions; create the build directory and copy the source code.
+# The last command is necessary to ensure our preparation instructions remain compatible with the patching system.
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+	cp -r $(SOURCE_DIR)/* $(PKG_BUILD_DIR)
+	$(Build/Patch)
+endef
+
+# Package install instructions; create a directory inside the package to hold our executable, and then copy the executable we built previously into the folder
+define Package/tinyHIPPO/install
+	$(INSTALL_DIR) $(1)/etc/tinyHIPPO
+	# Install all the source files
+	$(INSTALL_DIR) $(1)/etc/tinyHIPPO/src
+	$(CP) $(PKG_BUILD_DIR)/src/* $(1)/etc/tinyHIPPO/src/
+	# Install all the setup files
+	$(INSTALL_DIR) $(1)/etc/tinyHIPPO/setup
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/setup/tinyHIPPO_db_setup.sql $(1)/etc/tinyHIPPO/setup
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/setup/tinyHIPPOstart $(1)/etc/tinyHIPPO
+	# Install all the core files and configs
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/tiny_hippo_run.py $(1)/etc/tinyHIPPO
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/config.py $(1)/etc/tinyHIPPO
+	$(INSTALL_DATA) $(PKG_BUILD_DIR)/config.json $(1)/etc/tinyHIPPO
+	# Install the symbolic
+	$(INSTALL_DIR) $(1)/usr/bin
+	ln -s /etc/tinyHIPPO/tinyHIPPOstart $(1)/usr/bin/tinyHIPPO
+	# Install the service files
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/setup/tinyHIPPOservice $(1)/etc/init.d/tinyHIPPOservice
+endef
+
+# This command is always the last, it uses the definitions and variables we give above in order to get the job done
+$(eval $(call BuildPackage,tinyHIPPO))

--- a/docs/openwrt_compile_source/README.md
+++ b/docs/openwrt_compile_source/README.md
@@ -1,0 +1,88 @@
+# Compiling tinyHIPPO from Source
+
+This document will instruct you through the process of compiling the tinyHIPPO OpenWrt package from source. Please note this is different than running `opkg install tinyHIPPO` on a router with OpenWrt on it.
+
+#### Misc. Notes
+This process will require access to some Unix based operating system, and the procedure outlined below used an Ubuntu 20.04 virtual machine
+
+This process also assumes all the directories created are in the user's home directory
+
+This process emulates the developer guide outlined at https://openwrt.org/docs/guide-developer/helloworld/start
+
+Credit for most of this procedure goes to the amazing folks over at OpenWrt.
+
+## Procedure
+
+###  Preparing Your System For Use
+First, clone the OpenWrt git repository:
+```git clone https://git.openwrt.org/openwrt/openwrt.git source```
+This will create the `source` directory in the home directory
+
+Second, we need to build any possible artifacts.
+```
+cd $HOME/source
+make distclean
+```
+Third, it is recommended to update and install the feeds packages to avoid any future potential problems.
+```
+./scripts/feeds update -a
+./scripts/feeds install -a
+```
+
+Fourth, we need to configure the cross-compilation toolchain by using the graphical configuration menu:
+```
+make menuconfig
+```
+The key in this step is to select the proper 'Target System', 'Subtarget', and 'Target Profile'. After making the selections, save your changes before exiting.
+
+Now, we can build the cross-compilation toolchain:
+```
+make toolchain/install
+```
+From personal experience, this step can take upwards of multiple hours, so grab a cup of coffee, walk the dog, and or read a book, it will be a while.
+
+Once we are finished building the toolchain, we need to make a slight adjustment to the path variable:
+```
+export PATH=$HOME/source/staging_dir/host/bin:$PATH
+```
+
+## Creating a Package
+Now we can begin the process of creating the actual package
+```
+cd $HOME
+mkdir -p mypackages/examples/tinyHIPPO
+mkdir -p mypackages/examples/tinyHIPPO/src
+```
+Next, copy over the Makefile included in this directory to the tinyHIPPO directory.
+
+```
+cp Makefile $HOME/mypackages/examples/tinyHIPPO
+```
+## Including New Package Feeds
+In order for us to compile the package properly, we need to ensure that we have linked the appropriate feeds.
+```
+cd $HOME/source
+touch feeds.conf
+```
+And with your favorite text editor (i.e. Vim) add the following to feeds.conf
+```
+src-link mypackages $HOME/mypackages
+```
+
+## Compiling the Package
+Now, run the script included in this directory from the terminal
+```
+./compile_tinyHIPPO_from_source.sh
+```
+This copy over the appropriate files to their proper locations, and compile the package. 
+
+The resulting *.ipk file will be located in 
+```
+$HOME/source/bin/packages/<arch>/mypackages
+```
+## Installing the Package
+Copy over the *.ipk file to the router and then run:
+```
+opkg install <file>
+```
+Now tinyHIPPO should be up and running on the router!

--- a/docs/openwrt_compile_source/compile_tinyHIPPO_from_source.sh
+++ b/docs/openwrt_compile_source/compile_tinyHIPPO_from_source.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Uninstall the old cids package
+echo 'Uninstalling old tinyHIPPO package'
+$HOME/source/scripts/feeds uninstall tinyHIPPO
+
+
+echo 'Going into the repo and changing to the main branch'
+cd $HOME/OpenWrt-IoT-IDS-Privacy && git checkout main
+
+echo 'Removing old files in tinyHIPPO'
+rm -r $HOME/mypackages/examples/tinyHIPPO/src/*
+
+echo 'Copying over the new files'
+cp -r $HOME/OpenWrt-IoT-IDS-Privacy/* $HOME/mypackages/examples/tinyHIPPO/src
+
+echo 'Updating package feeds to include new tinyHIPPO'
+$HOME/source/scripts/feeds update mypackages
+
+echo 'Installing the new tinyHIPPOdev in the package feeds'
+$HOME/source/scripts/feeds install -a -p mypackages
+
+echo 'Running make menuconfig'
+cd $HOME/source/ && make menuconfig
+
+echo 'COMPILING'
+cd $HOME/source/ && sudo make package/tinyHIPPO/compile V=sc

--- a/docs/openwrt_compile_source/compile_tinyHIPPO_from_source.sh
+++ b/docs/openwrt_compile_source/compile_tinyHIPPO_from_source.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Uninstall the old cids package
+# Uninstall the old tinyHIPPO package
 echo 'Uninstalling old tinyHIPPO package'
 $HOME/source/scripts/feeds uninstall tinyHIPPO
 


### PR DESCRIPTION
This PR has the documentation, Makefile, and script that is needed to compile tinyHIPPO from source if anyone wants to continue development. it is a pretty good overview of the process I use when I need to test out the PRs for changes to the source code.